### PR TITLE
expose sampling interval

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -434,6 +434,7 @@ var Board = function(port, options, callback) {
   this.currentBuffer = [];
   this.versionReceived = false;
   this.name = "Firmata";
+  this.settings = settings;
 
   if (typeof port === "object") {
     this.transport = port;

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -376,6 +376,7 @@ var Board = function(port, options, callback) {
   var board = this;
   var defaults = {
     reportVersionTimeout: 5000,
+    samplingInterval: 19,
     serialport: {
       baudRate: 57600,
       bufferSize: 1

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -1230,7 +1230,16 @@ Board.prototype._sendOneWireRequest = function(pin, subcommand, device, numBytes
 
 Board.prototype.setSamplingInterval = function(interval) {
   var safeint = interval < 10 ? 10 : (interval > 65535 ? 65535 : interval); // constrained
+  this.settings.samplingInterval = safeint;
   this.transport.write(new Buffer([START_SYSEX, SAMPLING_INTERVAL, (safeint & 0xFF), ((safeint >> 8) & 0xFF), END_SYSEX]));
+};
+
+/**
+ * Get sampling interval in millis. Default is 19 ms
+ */
+
+Board.prototype.getSamplingInterval = function(interval) {
+  return this.settings.samplingInterval;
 };
 
 /**


### PR DESCRIPTION
Can be useful to query the state of the board and set timers based on the query interval. Potential use case would be to shim `requestAnimationFrame` to sync with the board query interval.