### PR TITLE
initialize pins with defaults or options when capability query skipped

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -545,10 +545,10 @@ var Board = function(port, options, callback) {
         this.setSamplingInterval(settings.samplingInterval);
       }
       if (settings.skipCapabilities) {
-        this.analogPins = this.settings.analogPins || [ 14, 15, 16, 17, 18, 19 ];
+        this.analogPins = this.settings.analogPins || this.analogPins;
         this.pins = this.settings.pins || this.pins;
         if (!this.pins.length) {
-          for (var i = 0; i < (this.settings.pinCount || 20); i++) {
+          for (var i = 0; i < (this.settings.pinCount || 128); i++) {
             var analogChannel = this.analogPins.indexOf(i);
             if (analogChannel < 0) {
               analogChannel = 127;

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -79,6 +79,8 @@ var STEPPER = 0x72;
 var STRING_DATA = 0x71;
 var SYSTEM_RESET = 0xFF;
 
+var MAX_PIN_COUNT = 128;
+
 /**
  * MIDI_RESPONSE contains functions to be called when we receive a MIDI message from the arduino.
  * used as a switch object as seen here http://james.padolsey.com/javascript/how-to-avoid-switch-case-syndrome/
@@ -548,7 +550,7 @@ var Board = function(port, options, callback) {
         this.analogPins = settings.analogPins || this.analogPins;
         this.pins = settings.pins || this.pins;
         if (!this.pins.length) {
-          for (var i = 0; i < (settings.pinCount || 128); i++) {
+          for (var i = 0; i < (settings.pinCount || MAX_PIN_COUNT); i++) {
             var analogChannel = this.analogPins.indexOf(i);
             if (analogChannel < 0) {
               analogChannel = 127;

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -545,6 +545,17 @@ var Board = function(port, options, callback) {
         this.setSamplingInterval(settings.samplingInterval);
       }
       if (settings.skipCapabilities) {
+        this.analogPins = this.settings.analogPins || [ 14, 15, 16, 17, 18, 19 ];
+        this.pins = this.settings.pins || this.pins;
+        if (!this.pins.length) {
+          for (var i = 0; i < (this.settings.pinCount || 20); i++) {
+            var analogChannel = this.analogPins.indexOf(i);
+            if (analogChannel < 0) {
+              analogChannel = 127;
+            }
+            this.pins.push({supportedModes: [], analogChannel: analogChannel});
+          }
+        }
         ready();
       } else {
         this.queryCapabilities(function() {

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -545,10 +545,10 @@ var Board = function(port, options, callback) {
         this.setSamplingInterval(settings.samplingInterval);
       }
       if (settings.skipCapabilities) {
-        this.analogPins = this.settings.analogPins || this.analogPins;
-        this.pins = this.settings.pins || this.pins;
+        this.analogPins = settings.analogPins || this.analogPins;
+        this.pins = settings.pins || this.pins;
         if (!this.pins.length) {
-          for (var i = 0; i < (this.settings.pinCount || 128); i++) {
+          for (var i = 0; i < (settings.pinCount || 128); i++) {
             var analogChannel = this.analogPins.indexOf(i);
             if (analogChannel < 0) {
               analogChannel = 127;

--- a/test/firmata.test.js
+++ b/test/firmata.test.js
@@ -515,6 +515,51 @@ describe("board", function() {
     serialPort.emit("data", [ANALOG_MESSAGE | (1 & 0xF), 0 % 128, 0 >> 7]);
   });
 
+  it("should be able to read value of analog pin on a board that skipped capabilities check", function(done) {
+    var serialPort = new SerialPort("/path/to/fake/usb");
+    var board = new Board(serialPort, {skipCapabilities: true}, function(err) {});
+
+    board.on("ready", function() {
+      var counter = 0;
+      var order = [1023, 0, 1023, 0];
+      board.analogRead(1, function(value) {
+        if (value === 1023) {
+          counter++;
+        }
+        if (value === 0) {
+          counter++;
+        }
+        if (order[0] === value) {
+          order.shift();
+        }
+        if (counter === 4) {
+          order.length.should.equal(0);
+          done();
+        }
+      });
+
+      // Analog reporting turned on...
+      should.deepEqual(serialPort.lastWrite, [ 193, 1 ]);
+
+      // Single Byte
+      serialPort.emit("data", [ANALOG_MESSAGE | (1 & 0xF)]);
+      serialPort.emit("data", [1023 % 128]);
+      serialPort.emit("data", [1023 >> 7]);
+
+      serialPort.emit("data", [ANALOG_MESSAGE | (1 & 0xF)]);
+      serialPort.emit("data", [0 % 128]);
+      serialPort.emit("data", [0 >> 7]);
+
+      // Multi Byte
+      serialPort.emit("data", [ANALOG_MESSAGE | (1 & 0xF), 1023 % 128, 1023 >> 7]);
+      serialPort.emit("data", [ANALOG_MESSAGE | (1 & 0xF), 0 % 128, 0 >> 7]);
+    });
+
+    serialPort.emit("open");
+    board.emit("reportversion");
+    board.emit("queryfirmware");
+  });
+
   it("should be able to write a value to a digital output", function(done) {
     board.digitalWrite(3, board.HIGH);
     should.deepEqual(serialPort.lastWrite, [DIGITAL_MESSAGE, 8, 0]);
@@ -523,6 +568,25 @@ describe("board", function() {
     should.deepEqual(serialPort.lastWrite, [DIGITAL_MESSAGE, 0, 0]);
 
     done();
+  });
+
+  it("should be able to write a value to a digital output to a board that skipped capabilities check", function(done) {
+    var serialPort = new SerialPort("/path/to/fake/usb");
+    var board = new Board(serialPort, {skipCapabilities: true}, function(err) {});
+
+    board.on("ready", function() {
+      board.digitalWrite(3, board.HIGH);
+      should.deepEqual(serialPort.lastWrite, [DIGITAL_MESSAGE, 8, 0]);
+
+      board.digitalWrite(3, board.LOW);
+      should.deepEqual(serialPort.lastWrite, [DIGITAL_MESSAGE, 0, 0]);
+      done();
+    });
+
+    serialPort.emit("open");
+    board.emit("reportversion");
+    board.emit("queryfirmware");
+
   });
 
   it("should be able to write a value to an analog pin being used as a digital output", function(done) {

--- a/test/firmata.test.js
+++ b/test/firmata.test.js
@@ -517,7 +517,7 @@ describe("board", function() {
 
   it("should be able to read value of analog pin on a board that skipped capabilities check", function(done) {
     var serialPort = new SerialPort("/path/to/fake/usb");
-    var board = new Board(serialPort, {skipCapabilities: true}, function(err) {});
+    var board = new Board(serialPort, {skipCapabilities: true, analogPins: [14,15,16,17,18,19]}, function(err) {});
 
     board.on("ready", function() {
       var counter = 0;


### PR DESCRIPTION
First commit is tests that would fail without without this change.

The alternative to handling things this way could be with pin getters such as this branch:
https://github.com/monteslu/firmata/commit/94601b4725f86f4a5ba8077d4e0088c7b36bf990
