### PR TITLE
Use metaserialport to handle serialport@1 vs serialport@2

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -24,7 +24,7 @@ try {
   if (process.browser) {
     SerialPort = require("browser-serialport").SerialPort;
   } else {
-    SerialPort = require("serialport").SerialPort;
+    SerialPort = require("metaserialport").SerialPort;
   }
 } catch (err) {
   SerialPort = null;

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "browser-serialport": "*",
     "es6-map": "~0.1.1",
-    "object-assign": "~1.0.0",
-    "serialport": "1.7.4"
+    "grunt-cli": "^0.1.13",
+    "metaserialport": "^1.0.0",
+    "object-assign": "~1.0.0"
   },
-  "optionalDependencies": {},
   "scripts": {
     "test": "grunt"
   },


### PR DESCRIPTION
(this is based on v0.6.0, and so will conflict with current master, which solves the same problem differently)