### PR TITLE
Added detection for NW.js version 0.13+

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -22,7 +22,7 @@ var util = require("util"),
 
 
 try {
-  if (process.browser || parseFloat(process.versions["nw"]) >= 0.13) {
+  if (process.browser || parseFloat(process.versions.nw) >= 0.13) {
     com = require("browser-serialport");
   } else {
     com = global.IS_TEST_MODE ?

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -22,7 +22,7 @@ var util = require("util"),
 
 
 try {
-  if (process.browser) {
+  if (process.browser || parseFloat(process.versions['nw']) >= 0.13) {
     com = require("browser-serialport");
   } else {
     com = global.IS_TEST_MODE ?

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -22,7 +22,7 @@ var util = require("util"),
 
 
 try {
-  if (process.browser || parseFloat(process.versions['nw']) >= 0.13) {
+  if (process.browser || parseFloat(process.versions["nw"]) >= 0.13) {
     com = require("browser-serialport");
   } else {
     com = global.IS_TEST_MODE ?


### PR DESCRIPTION
Since v0.13, **NW.js** fully supports the `chrome.*` APIs. This includes `chrome.serial` upon which **browser-serialport** is constructed. This pull request simply detects if the **firmata** module is being run inside **NW.js** in which case it uses the **browser-serialport** module instead of the **serialport** module.

Since native modules need to be specifically recompiled for **NW.js**, this makes it much easier to use the serial port in that environment.