### PR TITLE
I2C: support the stopTX flag

### DIFF
--- a/examples/mma8452.js
+++ b/examples/mma8452.js
@@ -1,0 +1,104 @@
+var Board = require("../");
+
+Board.requestPort(function(error, port) {
+  if (error) {
+    console.log(error);
+    return;
+  }
+
+  var register = {
+    CTRL_REG1: 0x2A,
+    XYZ_DATA_CFG: 0x0E,
+    READ_X_MSB: 0x01,
+  };
+
+  var board = new Board(port.comName);
+  // var board = new Board("/dev/cu.usbmodem1411");
+
+  board.on("ready", function() {
+    console.log("Ready");
+
+    var mma8452 = 0x1D;
+    var scale = 2; // 2G
+    var options = {
+      address: mma8452,
+      settings: {
+        stopTX: false,
+      },
+    };
+
+    this.i2cConfig(options);
+
+    function mode(which, callback) {
+      board.i2cReadOnce(mma8452, register.CTRL_REG1, 1, function(data) {
+        var value = data[0];
+        if (which === "standby") {
+          // Clear the first bit
+          value &= ~1;
+        } else {
+          // Set the first bit
+          value |= 1;
+        }
+
+        board.i2cWrite(mma8452, register.CTRL_REG1, value);
+
+        callback();
+      });
+    }
+
+    new Promise(function(resolve) {
+      mode("standby", function() {
+
+        // 00: 2G (0b00000000)
+        // 01: 4G (0b00000001)
+        // 10: 8G (0b00000010)
+        var fsr = scale >> 2; // 2G (0b00000000)
+        board.i2cWrite(mma8452, register.XYZ_DATA_CFG, fsr);
+
+        // 0: 800 Hz
+        // 1: 400 Hz
+        // 2: 200 Hz *
+        // 3: 100 Hz
+        // 4: 50 Hz
+        // 5: 12.5 Hz
+        // 6: 6.25 Hz
+        // 7: 1.56 Hz
+        var ctrlreg1 = 0b00000101 << 3; // 5 0b00[101]000
+        board.i2cWrite(mma8452, register.CTRL_REG1, ctrlreg1);
+
+        mode("active", resolve);
+      });
+    }).then(function() {
+
+      board.i2cRead(mma8452, 0x00, 1, function(data) {
+        var available = data[0];
+
+        if ((available & 0x08) >> 3) {
+          board.i2cReadOnce(mma8452, register.READ_X_MSB, 6, function(data) {
+            var x = (data[0] << 8 | data[1]) >> 4;
+            var y = (data[2] << 8 | data[3]) >> 4;
+            var z = (data[4] << 8 | data[5]) >> 4;
+
+            if (data[0] > 0x7F) {
+              x = -(1 + 0xFFF - x);
+            }
+
+            if (data[2] > 0x7F) {
+              y = -(1 + 0xFFF - y);
+            }
+
+            if (data[4] > 0x7F) {
+              z = -(1 + 0xFFF - z);
+            }
+
+            console.log({
+              x: x / ((1 << 12) / (2 * scale)),
+              y: y / ((1 << 12) / (2 * scale)),
+              z: z / ((1 << 12) / (2 * scale)),
+            });
+          });
+        }
+      });
+    });
+  });
+});

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -51,6 +51,8 @@ var EXTENDED_ANALOG = 0x6F;
 var I2C_CONFIG = 0x78;
 var I2C_REPLY = 0x77;
 var I2C_REQUEST = 0x76;
+var I2C_READ_MASK = 0x18;   // 0b00011000
+var I2C_END_TX_MASK = 0x40; // 0b01000000
 var ONEWIRE_CONFIG_REQUEST = 0x41;
 var ONEWIRE_DATA = 0x73;
 var ONEWIRE_DELAY_REQUEST_BIT = 0x10;
@@ -438,7 +440,7 @@ var Board = function(port, options, callback) {
   };
 
   this.I2C_MODES = {
-    WRITE: 0x00,
+    WRITE: 0,
     READ: 1,
     CONTINUOUS_READ: 2,
     STOP_READING: 3
@@ -641,8 +643,6 @@ var Board = function(port, options, callback) {
       }
     });
   });
-
-  i2cActive.set(this, false);
 };
 
 util.inherits(Board, Emitter);
@@ -876,13 +876,34 @@ Board.prototype.sendString = function(string) {
   this.transport.write(data);
 };
 
-function i2cRequest(board, buffer) {
+function i2cRequest(board, bytes) {
+  var active = i2cActive.get(board);
 
-  if (!i2cActive.get(board)) {
+  if (!active) {
     throw new Error("I2C is not enabled for this board. To enable, call the i2cConfig() method.");
   }
 
-  board.transport.write(buffer);
+  // Do not tamper with I2C_CONFIG messages
+  if (bytes[1] === I2C_REQUEST) {
+    var address = bytes[2];
+
+    // If no peripheral settings exist, make them.
+    if (!active[address]) {
+      active[address] = {
+        stopTX: true,
+      };
+    }
+
+    // READ (8) or CONTINUOUS_READ (16)
+    // value & 0b00011000
+    if (bytes[3] & I2C_READ_MASK) {
+      // Invert logic to accomodate default = true,
+      // which is actually stopTX = 0
+      bytes[3] |= Number(!active[address].stopTX) << 6;
+    }
+  }
+
+  board.transport.write(new Buffer(bytes));
 }
 
 /**
@@ -910,28 +931,60 @@ Board.prototype.sendI2CConfig = function(delay) {
  */
 
 Board.prototype.i2cConfig = function(options) {
+  var settings = i2cActive.get(this);
   var delay;
+
+  if (!settings) {
+    settings = {
+      /*
+        Keys will be I2C peripheral addresses
+       */
+    };
+    i2cActive.set(this, settings);
+  }
 
   if (typeof options === "number") {
     delay = options;
   } else {
     if (typeof options === "object" && options !== null) {
-      delay = options.delay;
+      delay = Number(options.delay);
+
+      // When an address was explicitly specified, there may also be
+      // peripheral specific instructions in the config.
+      if (typeof options.address !== "undefined") {
+
+        if (!settings[options.address]) {
+          settings[options.address] = {
+            stopTX: true,
+          };
+        }
+
+        // When settings have been explicitly provided, just bulk assign
+        // them to the existing settings, even if that's empty. This
+        // allows for reconfiguration as needed.
+        if (typeof options.settings) {
+          Object.assign(settings[options.address], options.settings);
+          /*
+            - stopTX: true | false
+                Set `stopTX` to `false` if this peripheral
+                expects Wire to keep the transmission connection alive between
+                setting a register and requesting bytes.
+
+                Defaults to `true`.
+           */
+        }
+      }
     }
   }
 
-  delay = delay || 0;
+  settings.delay = delay = delay || 0;
 
-  i2cActive.set(this, true);
-
-  i2cRequest(this,
-    new Buffer([
-      START_SYSEX,
-      I2C_CONFIG,
-      delay & 0xFF, (delay >> 8) & 0xFF,
-      END_SYSEX
-    ])
-  );
+  i2cRequest(this, [
+    START_SYSEX,
+    I2C_CONFIG,
+    delay & 0xFF, (delay >> 8) & 0xFF,
+    END_SYSEX
+  ]);
 
   return this;
 };
@@ -961,7 +1014,7 @@ Board.prototype.sendI2CWriteRequest = function(slaveAddress, bytes) {
 
   data.push(END_SYSEX);
 
-  i2cRequest(this, new Buffer(data));
+  i2cRequest(this, data);
 };
 
 /**
@@ -996,7 +1049,6 @@ Board.prototype.i2cWrite = function(address, registerOrData, inBytes) {
     this.I2C_MODES.WRITE << 3
   ];
 
-
   // If i2cWrite was used for an i2cWriteReg call...
   if (arguments.length === 3 &&
       !Array.isArray(registerOrData) &&
@@ -1025,7 +1077,7 @@ Board.prototype.i2cWrite = function(address, registerOrData, inBytes) {
 
   data.push(END_SYSEX);
 
-  i2cRequest(this, new Buffer(data));
+  i2cRequest(this, data);
 
   return this;
 };
@@ -1040,19 +1092,17 @@ Board.prototype.i2cWrite = function(address, registerOrData, inBytes) {
  */
 
 Board.prototype.i2cWriteReg = function(address, register, byte) {
-  i2cRequest(this,
-    new Buffer([
-      START_SYSEX,
-      I2C_REQUEST,
-      address,
-      this.I2C_MODES.WRITE << 3,
-      // register
-      register & 0x7F, (register >> 7) & 0x7F,
-      // byte
-      byte & 0x7F, (byte >> 7) & 0x7F,
-      END_SYSEX
-    ])
-  );
+  i2cRequest(this, [
+    START_SYSEX,
+    I2C_REQUEST,
+    address,
+    this.I2C_MODES.WRITE << 3,
+    // register
+    register & 0x7F, (register >> 7) & 0x7F,
+    // byte
+    byte & 0x7F, (byte >> 7) & 0x7F,
+    END_SYSEX
+  ]);
 
   return this;
 };
@@ -1066,16 +1116,14 @@ Board.prototype.i2cWriteReg = function(address, register, byte) {
  */
 
 Board.prototype.sendI2CReadRequest = function(address, numBytes, callback) {
-  i2cRequest(this,
-    new Buffer([
-      START_SYSEX,
-      I2C_REQUEST,
-      address,
-      this.I2C_MODES.READ << 3,
-      numBytes & 0x7F, (numBytes >> 7) & 0x7F,
-      END_SYSEX
-    ])
-  );
+  i2cRequest(this, [
+    START_SYSEX,
+    I2C_REQUEST,
+    address,
+    this.I2C_MODES.READ << 3,
+    numBytes & 0x7F, (numBytes >> 7) & 0x7F,
+    END_SYSEX
+  ]);
   this.once("I2C-reply-" + address + "-0" , callback);
 };
 
@@ -1126,7 +1174,7 @@ Board.prototype.i2cRead = function(address, register, bytesToRead, callback) {
 
   this.on(event, callback);
 
-  i2cRequest(this, new Buffer(data));
+  i2cRequest(this, data);
 
   return this;
 };
@@ -1181,7 +1229,7 @@ Board.prototype.i2cReadOnce = function(address, register, bytesToRead, callback)
 
   this.once(event, callback);
 
-  i2cRequest(this, new Buffer(data));
+  i2cRequest(this, data);
 
   return this;
 };
@@ -1735,5 +1783,16 @@ Board.requestPort = function(callback) {
 Board.Board = Board;
 Board.SYSEX_RESPONSE = SYSEX_RESPONSE;
 Board.MIDI_RESPONSE = MIDI_RESPONSE;
+
+if (global.IS_TEST_MODE) {
+  Board.test = {
+    i2cPeripheralSettings: function(board) {
+      return i2cActive.get(board);
+    },
+    get i2cActive() {
+      return i2cActive;
+    }
+  };
+}
 
 module.exports = Board;

--- a/readme.md
+++ b/readme.md
@@ -139,23 +139,25 @@ If you run *firmata* from the command line it will prompt you for the serial por
   
 ### I2C
   
-- `i2cConfig(options)` 
-
-  Configure and enable I2C, provide no options or delay. Required to enable I2C communication. 
-  ```js
-  options {
-    delay: Number in μs
-  }
-  ```
-
 - `i2cConfig(delay)` 
 
   Configure and enable I2C, optionally provide a value in μs to delay between reads (defaults to `0`). Required to enable I2C communication. 
 
 - `i2cConfig(options)` 
 
-  Configure and enable I2C, optionally provide an object that contains a `delay` property whose value is a number in μs to delay between reads. Required to enable I2C communication. 
+  Configure and enable I2C, optionally provide an object that contains properties to use for  whose value is a number in μs to delay between reads. Required to enable I2C communication. 
+  
+  | Option  | Description | Default | Required? |
+  |---------|-------------|---------|-----------|
+  | delay   | µS delay between setting a register and requesting bytes from the register | 0 | No |
+  | address | Valid I2C address, used when there are specific configurations for a given address | none | No |
+  | settings | An object of properties to associate with a given address. | none | No |
 
+
+  | Setting | Description | Default | Required? |
+  |---------|-------------|---------|-----------|
+  | stopTX  | Stop transmission after setting a register to read from. Setting to `false` will keep the transmission connection active. An example of the `false` behavior is the [MMA8452](https://github.com/sparkfun/MMA8452_Accelerometer/blob/master/Libraries/Arduino/src/SparkFun_MMA8452Q.cpp#L242-L270) | true | No |
+  
 
 - `i2cWrite(address, [...bytes])` 
 


### PR DESCRIPTION
By taking advantage of the `i2cConfig({ options object })` I was able to implement support for the `stopTX` flag such that no existing code will have to change to accommodate this feature. Implementors may call and recall `i2cConfig` as needed to configure or reconfigure an I2C peripheral by address. 