### PR TITLE
parser improvements

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -387,7 +387,6 @@ SYSEX_RESPONSE[SERIAL_MESSAGE] = function(board) {
   }
 };
 
-
 /**
  * @class The Board object represents an arduino board.
  * @augments EventEmitter
@@ -541,13 +540,7 @@ var Board = function(port, options, callback) {
   }.bind(this));
 
   this.transport.on("data", function(data) {
-    var byt, cmd;
-
-    if (!this.versionReceived && data[0] !== REPORT_VERSION) {
-      return;
-    } else {
-      this.versionReceived = true;
-    }
+    var byt, cmd, currByte;
 
     for (var i = 0; i < data.length; i++) {
       byt = data[i];
@@ -562,8 +555,17 @@ var Board = function(port, options, callback) {
           SYSEX_RESPONSE[this.currentBuffer[1]] &&
           this.currentBuffer[this.currentBuffer.length - 1] === END_SYSEX) {
 
-          SYSEX_RESPONSE[this.currentBuffer[1]](this);
+          if (this.versionReceived) {
+            SYSEX_RESPONSE[this.currentBuffer[1]](this);
+          }
           this.currentBuffer.length = 0;
+        } else if (this.currentBuffer[0] === START_SYSEX && i > 0) {
+          // we have a new command after an incomplete sysex command
+          currByte = this.currentBuffer[i];
+          if (currByte > 0x7F) {
+            this.currentBuffer.length = 0;
+            this.currentBuffer.push(currByte);
+          }
         } else if (this.currentBuffer[0] !== START_SYSEX) {
           // Check if data gets out of sync: first byte in buffer
           // must be a valid command if not START_SYSEX
@@ -589,7 +591,10 @@ var Board = function(port, options, callback) {
           }
 
           if (MIDI_RESPONSE[cmd]) {
-            MIDI_RESPONSE[cmd](this);
+            if (this.versionReceived || this.currentBuffer[0] === REPORT_VERSION) {
+              this.versionReceived = true;
+              MIDI_RESPONSE[cmd](this);
+            }
             this.currentBuffer.length = 0;
           } else {
             // A bad serial read must have happened.


### PR DESCRIPTION
This PR fixes 2 issues with the parser logic:

1. Described [here](https://github.com/jgautier/firmata/issues/114)
2. Writing tests against the parser revealed that parsing was broken if an incomplete sysex command was received.

The solution I've implemented for number 1 above warrants a discussion. I've written it in a way that replicates the existing behavior of preventing command events from being dispatched until after `REPORT_VERSION` has been received. There are pros and cons to this approach.

Pros:
- Prevents user from receiving unexpected data - especially when using a non-Serial transport that does not reset the board upon reconnecting.

Cons:
- Is potentially fragile and forces an application to begin with a valid `REPORT_VERSION` event.

I think the pros currently outweigh the cons. Otherwise a user may receive analog input events when they haven't enabled analog reporting yet (because the board isn't reset). Another approach would be to make the `versionReceived` property accessible through a configuration parameter. It would be for more advanced uses only - when an application may be susceptible to multiple reconnection events and is using `skipCapabilities` (since `REPORT_VERSION` is always needed if using the configuration query).

I haven't tested this on actual hardware yet. Opening now to start a discussion.

@rwaldron fyi